### PR TITLE
remove duplicate <h1> from  native examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $htmlString = <<<HTMLDOC
        <head>
        </head>
        <body>
-           <my-header><h1>Hello World</h1></my-header>
+           <my-header>Hello World</my-header>
        </body>
        </html>
 HTMLDOC;

--- a/examples/native-ssr/public/index.php
+++ b/examples/native-ssr/public/index.php
@@ -22,7 +22,7 @@ $htmlString = <<<HTMLDOC
        <head>
        </head>
        <body>
-           <my-header><h1>Hello World</h1></my-header>
+           <my-header>Hello World</my-header>
        </body>
        </html>
 HTMLDOC;


### PR DESCRIPTION
Running the native example was producing invalid HTML with nested `<h1>`s:

```html
<my-header enhanced="✨">  
    <h1><h1>Hello World</h1></h1></my-header>
```

`my-header.php` wraps the `<slot>` in an `<h1>` in both the native and WASM examples.

This PR updates the native `$htmlString` example in both the README and `index.php` to remove the extra `<h1>`.